### PR TITLE
Improved performance and fixed bug (plus some additions)

### DIFF
--- a/Elevator/client.lua
+++ b/Elevator/client.lua
@@ -86,7 +86,7 @@ Citizen.CreateThread(function()
                     end
                     if floorDown then
                         -- Show prompt to go down
-                        message = message .. "~n~" .. "~INPUT_FRONTEND_DOWN~ " .. (floorDown[4] or "Floor " .. k - 1)
+                        message = message .. "~n~" .. "~INPUT_FRONTEND_DOWN~ " .. (floorDown[2] or "Floor " .. k - 1)
                     end
 
                     -- Sent information how to use

--- a/Elevator/client.lua
+++ b/Elevator/client.lua
@@ -55,7 +55,7 @@ Citizen.CreateThread(function()
     end
     while true do
         Citizen.Wait(5)
-        local player = GetPlayerPed(-1)
+        local player = PlayerPedId()
         local PlayerLocation = GetEntityCoords(player)
 
         for i = 1, #elevators do


### PR DESCRIPTION
Following the feedback given in #1  I've made some changes to fix the listed bug and improve the points as noted.

I've also made it so:
 - You can set a name per floor (or its index is used)
 - Prompt only shows the directions you can go, rather than show an UP prompt when you're at the top floor
 - Prompt now shows the current floor and the names of the floors you can go to
https://cdn.tycoon.community/rrerr/1astp.png